### PR TITLE
Fix nightly test failure

### DIFF
--- a/const_format/tests/misc_tests/assertcp_tests.rs
+++ b/const_format/tests/misc_tests/assertcp_tests.rs
@@ -104,6 +104,7 @@ const _: () = {
         },
         "world{foo}",
         foo = {
+            #[allow(unconditional_panic)]
             let foo: u8 = [][0];
             foo
         },


### PR DESCRIPTION
Nightly enabled `#[deny(unconditional_panic)]` by default. This allows it in the one place that triggers it.