### PR TITLE
Put miri in super-strict mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
         cargo test --features "testing derive constant_time_as_str assertc"
 
         MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
-        MIRIFLAGS=-Zmiri-strict-provenance -Zmiri-check-number-validity -Zmiri-symbolic-alignment-check
+        MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-check-number-validity -Zmiri-symbolic-alignment-check"
         echo "Installing latest nightly with Miri"
         echo "$MIRI_NIGHTLY"
         rustup set profile minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,7 @@ jobs:
         cargo test --features "testing derive constant_time_as_str assertc"
 
         MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+        MIRIFLAGS=-Zmiri-strict-provenance -Zmiri-check-number-validity -Zmiri-symbolic-alignment-check
         echo "Installing latest nightly with Miri"
         echo "$MIRI_NIGHTLY"
         rustup set profile minimal

--- a/const_format/tests/misc_tests/assertcp_tests.rs
+++ b/const_format/tests/misc_tests/assertcp_tests.rs
@@ -104,6 +104,7 @@ const _: () = {
         },
         "world{foo}",
         foo = {
+            #[allow(unconditional_panic)]
             let foo: u8 = [][0];
             foo
         },


### PR DESCRIPTION
Specifically:

- `-Zmiri-strict-provenance`: validate that the code respects [strict provenance](https://github.com/rust-lang/rust/issues/95228) (roughly: `usize as ptr` doesn't produce a usable pointer).
- `-Zmiri-check-number-validity`: validate that numbers are initialized and do not carry provenance (i.e. `transmute<ptr, usize>` is banned).
- `-Zmiri-symbolic-alignment-check` (SPICY): validate alignment is statically correct, not just "happens to be" correct.

Everything works with the strict mode flags 🎉 (modulo #31)