### PR TITLE
Added type coercion to &str for concatcp! macro

### DIFF
--- a/const_format/src/macros/fmt_macros.rs
+++ b/const_format/src/macros/fmt_macros.rs
@@ -60,7 +60,7 @@ macro_rules! concatcp {
         $crate::pmr::__concatcp_impl!{
             $( ( $arg ), )*
         }
-    } as &str );
+    } as &'static $crate::__::str );
 }
 
 #[doc(hidden)]
@@ -262,7 +262,7 @@ macro_rules! formatcp {
         $crate::pmr::__formatcp_impl!(
             ($format_string)
             $(, $($expr,)+)?
-        )
+        ) as &'static $crate::__::str
     });
 }
 
@@ -329,6 +329,7 @@ macro_rules! concatc {
         use $crate::__cf_osRcTFl4A;
 
         $crate::__concatc_expr!(($($anything)*) ($($anything)*))
+        as &'static $crate::__::str
     })
 }
 
@@ -498,7 +499,7 @@ macro_rules! formatc {
         $crate::pmr::__formatc_impl!{
             ($format_string)
             $(, $($expr,)+)?
-        }
+        } as &'static $crate::__::str
     });
 }
 

--- a/const_format/src/macros/fmt_macros.rs
+++ b/const_format/src/macros/fmt_macros.rs
@@ -55,12 +55,14 @@
 #[macro_export]
 macro_rules! concatcp {
     ()=>{""};
-    ($($arg: expr),* $(,)?)=>({
-        use $crate::__cf_osRcTFl4A;
-        $crate::pmr::__concatcp_impl!{
-            $( ( $arg ), )*
-        }
-    } as &'static $crate::__::str );
+    ($($arg: expr),* $(,)?)=>(
+        {
+            use $crate::__cf_osRcTFl4A;
+            $crate::pmr::__concatcp_impl!{
+                $( ( $arg ), )*
+            }
+        } as &'static $crate::pmr::str
+    );
 }
 
 #[doc(hidden)]
@@ -256,14 +258,16 @@ macro_rules! __concatcp_inner {
 ///
 #[macro_export]
 macro_rules! formatcp {
-    ($format_string:expr $( $(, $expr:expr )+ )? $(,)? ) => ({
-        use $crate::__cf_osRcTFl4A;
+    ($format_string:expr $( $(, $expr:expr )+ )? $(,)? ) => (
+        {
+            use $crate::__cf_osRcTFl4A;
 
-        $crate::pmr::__formatcp_impl!(
-            ($format_string)
-            $(, $($expr,)+)?
-        ) as &'static $crate::__::str
-    });
+            $crate::pmr::__formatcp_impl!(
+                ($format_string)
+                $(, $($expr,)+)?
+            )
+        } as &'static $crate::pmr::str
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -325,12 +329,14 @@ macro_rules! formatcp {
 #[macro_export]
 macro_rules! concatc {
     ()=>{""};
-    ($($anything:tt)*)=>({
-        use $crate::__cf_osRcTFl4A;
+    ($($anything:tt)*)=>(
+        {
+            use $crate::__cf_osRcTFl4A;
 
-        $crate::__concatc_expr!(($($anything)*) ($($anything)*))
-        as &'static $crate::__::str
-    })
+            $crate::__concatc_expr!(($($anything)*) ($($anything)*))
+            as &'static $crate::pmr::str
+        }
+    )
 }
 
 #[doc(hidden)]
@@ -493,14 +499,16 @@ macro_rules! __concatc_inner {
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "fmt")))]
 #[cfg(feature = "fmt")]
 macro_rules! formatc {
-    ($format_string:expr $( $(, $expr:expr )+ )? $(,)? ) => ({
-        use $crate::__cf_osRcTFl4A;
+    ($format_string:expr $( $(, $expr:expr )+ )? $(,)? ) => (
+        {
+            use $crate::__cf_osRcTFl4A;
 
-        $crate::pmr::__formatc_impl!{
-            ($format_string)
-            $(, $($expr,)+)?
-        } as &'static $crate::__::str
-    });
+            $crate::pmr::__formatc_impl!{
+                ($format_string)
+                $(, $($expr,)+)?
+            }
+        } as &'static $crate::pmr::str
+    );
 }
 
 /// Writes some formatted standard library and/or user-defined types into a buffer.

--- a/const_format/src/macros/fmt_macros.rs
+++ b/const_format/src/macros/fmt_macros.rs
@@ -60,7 +60,7 @@ macro_rules! concatcp {
         $crate::pmr::__concatcp_impl!{
             $( ( $arg ), )*
         }
-    });
+    } as &str );
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
As without this type inference in CLion/Intelij Rust goes crazy.
Due to presence of proc macros Intelij Rust plugin is unable to infer
type and it infers it as `()`

Example before fix:
![image](https://user-images.githubusercontent.com/775038/164796050-121d0d6a-4990-4d30-9f2c-f01c74e84c97.png)
After fix:
![image](https://user-images.githubusercontent.com/775038/164796481-e257fdb5-efdb-4d2b-87ec-dd5611e2646c.png)
