### PR TITLE
Bumped version to 0.2.25, fixed some clippy/rustc warnings,

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,17 @@ This is the changelog,summarising changes in each version(some minor changes may
 
 # 0.2 
 
+### 0.2.25
+
+Fixed the `clippy::double_parens` (false positive) warning by 
+encoding the `&'static str` type annotation some other way.
+
+Made `SplicedStr`, `Formatting`, `NumberFormatting`, 
+
+### 0.2.24
+
+Fixed error that caused formatting macros not to be usable in statement position.
+
 ### 0.2.23
 
 Added type annotations to `concatp`, `concatcp`, `formatc` and `formatcp` macros to help IDEs infer the type.

--- a/const_format/Cargo.toml
+++ b/const_format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_format"
-version = "0.2.24"
+version = "0.2.25"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2018"
 license = "Zlib"

--- a/const_format/src/__str_methods/str_splice.rs
+++ b/const_format/src/__str_methods/str_splice.rs
@@ -27,7 +27,7 @@ pub struct StrSpliceArgs {
 }
 
 /// The return value of [`str_splice`](./macro.str_splice.html)
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SplicedStr {
     /// A string that had `removed` replaced with some other string.
     pub output: &'static str,

--- a/const_format/src/formatting.rs
+++ b/const_format/src/formatting.rs
@@ -1,5 +1,5 @@
 #[doc(hidden)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Formatting {
     Debug,
     Display,
@@ -19,7 +19,7 @@ impl Formatting {
 /// debug formatting.
 ///
 ///
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NumberFormatting {
     /// Formats numbers as decimal
     Decimal,

--- a/const_format/src/lib.rs
+++ b/const_format/src/lib.rs
@@ -350,11 +350,7 @@
 //!
 #![no_std]
 #![cfg_attr(feature = "fmt", feature(const_mut_refs))]
-#![cfg_attr(feature = "assertc", feature(const_panic))]
-#![cfg_attr(
-    feature = "constant_time_as_str",
-    feature(const_slice_from_raw_parts, const_fn_union,)
-)]
+#![cfg_attr(feature = "constant_time_as_str", feature(const_slice_from_raw_parts))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]
 #![deny(rust_2018_idioms)]
 // This lint is silly
@@ -366,6 +362,7 @@
 #![deny(clippy::wildcard_imports)]
 // All The methods that take self by value are for small Copy types
 #![allow(clippy::wrong_self_convention)]
+#![allow(clippy::init_numbered_fields)]
 #![deny(missing_docs)]
 
 include! {"const_debug_derive.rs"}
@@ -504,6 +501,12 @@ pub mod pmr {
         pargument::{PArgument, PConvWrapper, PVariant},
         wrapper_types::PWrapper,
     };
+
+    #[doc(hidden)]
+    #[repr(transparent)]
+    pub struct __AssertStr {
+        pub x: &'static str,
+    }
 }
 
 #[cfg(all(test, not(feature = "testing")))]

--- a/const_format/src/macros/fmt_macros.rs
+++ b/const_format/src/macros/fmt_macros.rs
@@ -56,12 +56,12 @@
 macro_rules! concatcp {
     ()=>{""};
     ($($arg: expr),* $(,)?)=>(
-        ({
+        $crate::pmr::__AssertStr {x:{
             use $crate::__cf_osRcTFl4A;
             $crate::pmr::__concatcp_impl!{
                 $( ( $arg ), )*
             }
-        } as &'static $crate::pmr::str)
+        }}.x
     );
 }
 
@@ -259,14 +259,14 @@ macro_rules! __concatcp_inner {
 #[macro_export]
 macro_rules! formatcp {
     ($format_string:expr $( $(, $expr:expr )+ )? $(,)? ) => (
-        ({
+        $crate::pmr::__AssertStr {x:{
             use $crate::__cf_osRcTFl4A;
 
             $crate::pmr::__formatcp_impl!(
                 ($format_string)
                 $(, $($expr,)+)?
             )
-        } as &'static $crate::pmr::str)
+        }}.x
     );
 }
 
@@ -330,12 +330,12 @@ macro_rules! formatcp {
 macro_rules! concatc {
     ()=>{""};
     ($($anything:tt)*)=>(
-        ({
+        $crate::pmr::__AssertStr {x:{
             use $crate::__cf_osRcTFl4A;
 
             $crate::__concatc_expr!(($($anything)*) ($($anything)*))
             as &'static $crate::pmr::str
-        })
+        }}.x
     )
 }
 
@@ -500,14 +500,14 @@ macro_rules! __concatc_inner {
 #[cfg(feature = "fmt")]
 macro_rules! formatc {
     ($format_string:expr $( $(, $expr:expr )+ )? $(,)? ) => (
-        ({
+        $crate::pmr::__AssertStr {x:{
             use $crate::__cf_osRcTFl4A;
 
             $crate::pmr::__formatc_impl!{
                 ($format_string)
                 $(, $($expr,)+)?
             }
-        } as &'static $crate::pmr::str)
+        }}.x
     );
 }
 

--- a/const_format/src/pargument.rs
+++ b/const_format/src/pargument.rs
@@ -131,7 +131,7 @@ impl PConvWrapper<PArgument> {
         self.0
     }
     #[inline]
-    pub const fn to_pargument_debug(self, fmt_flags: FormattingFlags) -> PArgument {
+    pub const fn to_pargument_debug(self, _: FormattingFlags) -> PArgument {
         self.0
     }
 }

--- a/const_format/tests/misc_tests/clippy_warnings.rs
+++ b/const_format/tests/misc_tests/clippy_warnings.rs
@@ -1,0 +1,5 @@
+#[deny(clippy::double_parens)]
+#[test]
+fn test_clippy_double_parens_not_triggered() {
+    std::convert::identity(cfmt_b::formatcp!("hello"));
+}

--- a/const_format/tests/misc_tests_modules.rs
+++ b/const_format/tests/misc_tests_modules.rs
@@ -12,6 +12,8 @@ mod misc_tests {
     #[cfg(not(feature = "only_new_tests"))]
     mod assertc_tests;
 
+    mod clippy_warnings;
+
     #[cfg(feature = "assertcp")]
     mod assertcp_tests;
 

--- a/const_format_proc_macros/src/format_args/parsing.rs
+++ b/const_format_proc_macros/src/format_args/parsing.rs
@@ -63,7 +63,7 @@ fn lit_str_to_fmt_lit(lit: &LitStr) -> Result<FormatStr, crate::Error> {
     let lit_str = lit.value();
     let format_str_span = lit.span;
     FormatStr::parse(lit.value(), lit.rawness)
-        .map_err(|e| e.into_crate_err(format_str_span, &lit_str))
+        .map_err(|e| e.into_crate_err(format_str_span, lit_str))
 }
 
 fn parse_fmt_lit(this: &mut FormatStr, input: ParseStream<'_>) -> Result<(), crate::Error> {

--- a/const_format_proc_macros/src/lib.rs
+++ b/const_format_proc_macros/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::or_fun_call)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 use proc_macro::TokenStream as TokenStream1;
 


### PR DESCRIPTION
Fixed the `clippy::double_parens` (false positive) warning by
encoding the `&'static str` type annotation some other way.

Made `SplicedStr`, `Formatting`, `NumberFormatting`,

Updated changelog

Fixes #38 