### PR TITLE
Fix `const-format` operation under `generic_const_args`

### DIFF
--- a/const_format/src/lib.rs
+++ b/const_format/src/lib.rs
@@ -449,7 +449,6 @@ pub mod pmr {
     pub use core::{
         cmp::Reverse,
         convert::identity,
-        mem::transmute,
         num::Wrapping,
         ops::Range,
         option::Option::{self, None, Some},

--- a/const_format/src/macros/fmt_macros.rs
+++ b/const_format/src/macros/fmt_macros.rs
@@ -79,9 +79,8 @@ macro_rules! __concatcp_inner {
         #[doc(hidden)]
         #[allow(clippy::transmute_ptr_to_ptr)]
         const CONCAT_STR: &str = unsafe {
-            // This transmute truncates the length of the array to the amound of written bytes.
-            let slice =
-                $crate::pmr::transmute::<&[u8; ARR_LEN], &[u8; CONCAT_ARR.len]>(&CONCAT_ARR.array);
+            // This truncates the length of the array to the amound of written bytes.
+            let slice = ::core::slice::from_raw_parts(CONCAT_ARR.array.as_ptr(), CONCAT_ARR.len);
 
             $crate::__priv_transmute_bytes_to_str!(slice)
         };


### PR DESCRIPTION
When enabling `generic_const_args` feature I was getting errors like this:
```
error: complex const arguments must be placed inside of a `const` block
   --> file.rs:?:?
    |
798 | ...                   &[u8; CONCAT_ARR.len],
    |                             ^^^^^^^^^^^^^^
```

Turns out `transmute` is completely unnecessary there and since array was cast into slice afterwards, slice can be created from the start, fixing the issue.

I'd appreciate a patch release with this :pray: 